### PR TITLE
Add search to top-level requests

### DIFF
--- a/src/Http/Requests/AbstractSearchRequest.php
+++ b/src/Http/Requests/AbstractSearchRequest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Perscom\RequestType;
+namespace Perscom\Http\Requests;
 
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;

--- a/src/Http/Requests/Announcements/SearchAnnouncementsRequest.php
+++ b/src/Http/Requests/Announcements/SearchAnnouncementsRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Announcements;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchAnnouncementsRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'announcements';
+    }
+}

--- a/src/Http/Requests/Announcements/SearchAnnouncementsRequest.php
+++ b/src/Http/Requests/Announcements/SearchAnnouncementsRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Announcements;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchAnnouncementsRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Awards/SearchAwardsRequest.php
+++ b/src/Http/Requests/Awards/SearchAwardsRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Awards;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchAwardsRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'awards';
+    }
+}

--- a/src/Http/Requests/Awards/SearchAwardsRequest.php
+++ b/src/Http/Requests/Awards/SearchAwardsRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Awards;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchAwardsRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Calendars/SearchCalendarsRequest.php
+++ b/src/Http/Requests/Calendars/SearchCalendarsRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Calendars;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchCalendarsRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'calendars';
+    }
+}

--- a/src/Http/Requests/Calendars/SearchCalendarsRequest.php
+++ b/src/Http/Requests/Calendars/SearchCalendarsRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Calendars;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchCalendarsRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Events/SearchEventsRequest.php
+++ b/src/Http/Requests/Events/SearchEventsRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Events;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchEventsRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Events/SearchEventsRequest.php
+++ b/src/Http/Requests/Events/SearchEventsRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Events;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchEventsRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'events';
+    }
+}

--- a/src/Http/Requests/Forms/SearchFormsRequest.php
+++ b/src/Http/Requests/Forms/SearchFormsRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Forms;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchFormsRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'forms';
+    }
+}

--- a/src/Http/Requests/Forms/SearchFormsRequest.php
+++ b/src/Http/Requests/Forms/SearchFormsRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Forms;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchFormsRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Groups/SearchGroupsRequest.php
+++ b/src/Http/Requests/Groups/SearchGroupsRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Groups;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchGroupsRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'groups';
+    }
+}

--- a/src/Http/Requests/Groups/SearchGroupsRequest.php
+++ b/src/Http/Requests/Groups/SearchGroupsRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Groups;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchGroupsRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Positions/SearchPositionsRequest.php
+++ b/src/Http/Requests/Positions/SearchPositionsRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Positions;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchPositionsRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'positions';
+    }
+}

--- a/src/Http/Requests/Positions/SearchPositionsRequest.php
+++ b/src/Http/Requests/Positions/SearchPositionsRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Positions;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchPositionsRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Qualifications/SearchQualificationsRequest.php
+++ b/src/Http/Requests/Qualifications/SearchQualificationsRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Qualifications;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchQualificationsRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Qualifications/SearchQualificationsRequest.php
+++ b/src/Http/Requests/Qualifications/SearchQualificationsRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Qualifications;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchQualificationsRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'qualifications';
+    }
+}

--- a/src/Http/Requests/Ranks/SearchRanksRequest.php
+++ b/src/Http/Requests/Ranks/SearchRanksRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Ranks;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchRanksRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'ranks';
+    }
+}

--- a/src/Http/Requests/Ranks/SearchRanksRequest.php
+++ b/src/Http/Requests/Ranks/SearchRanksRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Ranks;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchRanksRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Specialties/SearchSpecialtiesRequest.php
+++ b/src/Http/Requests/Specialties/SearchSpecialtiesRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Specialties;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchSpecialtiesRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'specialtys';
+    }
+}

--- a/src/Http/Requests/Specialties/SearchSpecialtiesRequest.php
+++ b/src/Http/Requests/Specialties/SearchSpecialtiesRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Specialties;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchSpecialtiesRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Submissions/SearchSubmissionsRequest.php
+++ b/src/Http/Requests/Submissions/SearchSubmissionsRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Submissions;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchSubmissionsRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Submissions/SearchSubmissionsRequest.php
+++ b/src/Http/Requests/Submissions/SearchSubmissionsRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Submissions;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchSubmissionsRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'submissions';
+    }
+}

--- a/src/Http/Requests/Tasks/SearchTasksRequest.php
+++ b/src/Http/Requests/Tasks/SearchTasksRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Tasks;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchTasksRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Tasks/SearchTasksRequest.php
+++ b/src/Http/Requests/Tasks/SearchTasksRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Tasks;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchTasksRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'tasks';
+    }
+}

--- a/src/Http/Requests/Units/SearchUnitsRequest.php
+++ b/src/Http/Requests/Units/SearchUnitsRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Units;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchUnitsRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'units';
+    }
+}

--- a/src/Http/Requests/Units/SearchUnitsRequest.php
+++ b/src/Http/Requests/Units/SearchUnitsRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Units;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchUnitsRequest extends AbstractSearchRequest
 {

--- a/src/Http/Requests/Users/SearchUsersRequest.php
+++ b/src/Http/Requests/Users/SearchUsersRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\Http\Requests\Users;
+
+use Perscom\RequestType\AbstractSearchRequest;
+
+class SearchUsersRequest extends AbstractSearchRequest
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getResource(): string
+    {
+        return 'users';
+    }
+}

--- a/src/Http/Requests/Users/SearchUsersRequest.php
+++ b/src/Http/Requests/Users/SearchUsersRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Perscom\Http\Requests\Users;
 
-use Perscom\RequestType\AbstractSearchRequest;
+use Perscom\Http\Requests\AbstractSearchRequest;
 
 class SearchUsersRequest extends AbstractSearchRequest
 {

--- a/src/Http/Resources/AnnouncementResource.php
+++ b/src/Http/Resources/AnnouncementResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Announcements\CreateAnnouncementRequest;
 use Perscom\Http\Requests\Announcements\DeleteAnnouncementRequest;
 use Perscom\Http\Requests\Announcements\GetAnnouncementRequest;
 use Perscom\Http\Requests\Announcements\GetAnnouncementsRequest;
+use Perscom\Http\Requests\Announcements\SearchAnnouncementsRequest;
 use Perscom\Http\Requests\Announcements\UpdateAnnouncementRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class AnnouncementResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetAnnouncementsRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchAnnouncementsRequest($data));
     }
 
     /**

--- a/src/Http/Resources/AwardResource.php
+++ b/src/Http/Resources/AwardResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Awards\CreateAwardRequest;
 use Perscom\Http\Requests\Awards\DeleteAwardRequest;
 use Perscom\Http\Requests\Awards\GetAwardRequest;
 use Perscom\Http\Requests\Awards\GetAwardsRequest;
+use Perscom\Http\Requests\Awards\SearchAwardsRequest;
 use Perscom\Http\Requests\Awards\UpdateAwardRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class AwardResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetAwardsRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchAwardsRequest($data));
     }
 
     /**

--- a/src/Http/Resources/CalendarResource.php
+++ b/src/Http/Resources/CalendarResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Calendars\CreateCalendarRequest;
 use Perscom\Http\Requests\Calendars\DeleteCalendarRequest;
 use Perscom\Http\Requests\Calendars\GetCalendarRequest;
 use Perscom\Http\Requests\Calendars\GetCalendarsRequest;
+use Perscom\Http\Requests\Calendars\SearchCalendarsRequest;
 use Perscom\Http\Requests\Calendars\UpdateCalendarRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class CalendarResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetCalendarsRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchCalendarsRequest($data));
     }
 
     /**

--- a/src/Http/Resources/EventResource.php
+++ b/src/Http/Resources/EventResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Events\CreateEventRequest;
 use Perscom\Http\Requests\Events\DeleteEventRequest;
 use Perscom\Http\Requests\Events\GetEventRequest;
 use Perscom\Http\Requests\Events\GetEventsRequest;
+use Perscom\Http\Requests\Events\SearchEventsRequest;
 use Perscom\Http\Requests\Events\UpdateEventRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class EventResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetEventsRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchEventsRequest($data));
     }
 
     /**

--- a/src/Http/Resources/FormResource.php
+++ b/src/Http/Resources/FormResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Forms\CreateFormRequest;
 use Perscom\Http\Requests\Forms\DeleteFormRequest;
 use Perscom\Http\Requests\Forms\GetFormRequest;
 use Perscom\Http\Requests\Forms\GetFormsRequest;
+use Perscom\Http\Requests\Forms\SearchFormsRequest;
 use Perscom\Http\Requests\Forms\UpdateFormRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class FormResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetFormsRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchFormsRequest($data));
     }
 
     /**

--- a/src/Http/Resources/GroupResource.php
+++ b/src/Http/Resources/GroupResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Groups\CreateGroupRequest;
 use Perscom\Http\Requests\Groups\DeleteGroupRequest;
 use Perscom\Http\Requests\Groups\GetGroupRequest;
 use Perscom\Http\Requests\Groups\GetGroupsRequest;
+use Perscom\Http\Requests\Groups\SearchGroupsRequest;
 use Perscom\Http\Requests\Groups\UpdateGroupRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class GroupResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetGroupsRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchGroupsRequest($data));
     }
 
     /**

--- a/src/Http/Resources/PositionResource.php
+++ b/src/Http/Resources/PositionResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Positions\CreatePositionRequest;
 use Perscom\Http\Requests\Positions\DeletePositionRequest;
 use Perscom\Http\Requests\Positions\GetPositionRequest;
 use Perscom\Http\Requests\Positions\GetPositionsRequest;
+use Perscom\Http\Requests\Positions\SearchPositionsRequest;
 use Perscom\Http\Requests\Positions\UpdatePositionRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class PositionResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetPositionsRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchPositionsRequest($data));
     }
 
     /**

--- a/src/Http/Resources/QualificationResource.php
+++ b/src/Http/Resources/QualificationResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Qualifications\CreateQualificationRequest;
 use Perscom\Http\Requests\Qualifications\DeleteQualificationRequest;
 use Perscom\Http\Requests\Qualifications\GetQualificationRequest;
 use Perscom\Http\Requests\Qualifications\GetQualificationsRequest;
+use Perscom\Http\Requests\Qualifications\SearchQualificationsRequest;
 use Perscom\Http\Requests\Qualifications\UpdateQualificationRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class QualificationResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetQualificationsRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchQualificationsRequest($data));
     }
 
     /**

--- a/src/Http/Resources/RankResource.php
+++ b/src/Http/Resources/RankResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Ranks\CreateRankRequest;
 use Perscom\Http\Requests\Ranks\DeleteRankRequest;
 use Perscom\Http\Requests\Ranks\GetRankRequest;
 use Perscom\Http\Requests\Ranks\GetRanksRequest;
+use Perscom\Http\Requests\Ranks\SearchRanksRequest;
 use Perscom\Http\Requests\Ranks\UpdateRankRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class RankResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetRanksRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchRanksRequest($data));
     }
 
     /**

--- a/src/Http/Resources/SpecialtyResource.php
+++ b/src/Http/Resources/SpecialtyResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Specialties\CreateSpecialtyRequest;
 use Perscom\Http\Requests\Specialties\DeleteSpecialtyRequest;
 use Perscom\Http\Requests\Specialties\GetSpecialtyRequest;
 use Perscom\Http\Requests\Specialties\GetSpecialtiesRequest;
+use Perscom\Http\Requests\Specialties\SearchSpecialtiesRequest;
 use Perscom\Http\Requests\Specialties\UpdateSpecialtyRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class SpecialtyResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetSpecialtiesRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchSpecialtiesRequest($data));
     }
 
     /**

--- a/src/Http/Resources/SubmissionResource.php
+++ b/src/Http/Resources/SubmissionResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Submissions\CreateSubmissionRequest;
 use Perscom\Http\Requests\Submissions\DeleteSubmissionRequest;
 use Perscom\Http\Requests\Submissions\GetSubmissionRequest;
 use Perscom\Http\Requests\Submissions\GetSubmissionsRequest;
+use Perscom\Http\Requests\Submissions\SearchSubmissionsRequest;
 use Perscom\Http\Requests\Submissions\UpdateSubmissionRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class SubmissionResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetSubmissionsRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchSubmissionsRequest($data));
     }
 
     /**

--- a/src/Http/Resources/TaskResource.php
+++ b/src/Http/Resources/TaskResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Tasks\CreateTaskRequest;
 use Perscom\Http\Requests\Tasks\DeleteTaskRequest;
 use Perscom\Http\Requests\Tasks\GetTaskRequest;
 use Perscom\Http\Requests\Tasks\GetTasksRequest;
+use Perscom\Http\Requests\Tasks\SearchTasksRequest;
 use Perscom\Http\Requests\Tasks\UpdateTaskRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class TaskResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetTasksRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchTasksRequest($data));
     }
 
     /**

--- a/src/Http/Resources/UnitResource.php
+++ b/src/Http/Resources/UnitResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Units\CreateUnitRequest;
 use Perscom\Http\Requests\Units\DeleteUnitRequest;
 use Perscom\Http\Requests\Units\GetUnitRequest;
 use Perscom\Http\Requests\Units\GetUnitsRequest;
+use Perscom\Http\Requests\Units\SearchUnitsRequest;
 use Perscom\Http\Requests\Units\UpdateUnitRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class UnitResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetUnitsRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchUnitsRequest($data));
     }
 
     /**

--- a/src/Http/Resources/UserResource.php
+++ b/src/Http/Resources/UserResource.php
@@ -7,6 +7,7 @@ use Perscom\Http\Requests\Users\CreateUserRequest;
 use Perscom\Http\Requests\Users\DeleteUserRequest;
 use Perscom\Http\Requests\Users\GetUserRequest;
 use Perscom\Http\Requests\Users\GetUsersRequest;
+use Perscom\Http\Requests\Users\SearchUsersRequest;
 use Perscom\Http\Requests\Users\UpdateUserRequest;
 use Saloon\Contracts\Response;
 
@@ -20,6 +21,15 @@ class UserResource extends Resource implements ResourceContract
     public function all(int $page = 1, int $limit = 20): Response
     {
         return $this->connector->send(new GetUsersRequest($page, $limit));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return Response
+     */
+    public function search(array $data): Response
+    {
+        return $this->connector->send(new SearchUsersRequest($data));
     }
 
     /**

--- a/src/RequestType/AbstractSearchRequest.php
+++ b/src/RequestType/AbstractSearchRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Perscom\RequestType;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+abstract class AbstractSearchRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::POST;
+
+    /**
+     * @param array<string, mixed>  $data
+     */
+    public function __construct(public array $data)
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function resolveEndpoint(): string
+    {
+        return "{$this->getResource()}/search";
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function defaultBody(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return string
+     */
+    abstract protected function getResource(): string;
+}

--- a/tests/Feature/UserRequestsTest.php
+++ b/tests/Feature/UserRequestsTest.php
@@ -4,6 +4,7 @@ use Perscom\Http\Requests\Users\CreateUserRequest;
 use Perscom\Http\Requests\Users\DeleteUserRequest;
 use Perscom\Http\Requests\Users\GetUserRequest;
 use Perscom\Http\Requests\Users\GetUsersRequest;
+use Perscom\Http\Requests\Users\SearchUsersRequest;
 use Perscom\Http\Requests\Users\UpdateUserRequest;
 use Perscom\PerscomConnection;
 use Saloon\Contracts\Request;
@@ -18,6 +19,14 @@ beforeEach(function () {
     $this->mockClient = new MockClient([
         GetUsersRequest::class => MockResponse::make([
             'name' => 'foo'
+        ], 200),
+        SearchUsersRequest::class => MockResponse::make([
+            'data' => [
+                [
+                    'id' => 1,
+                    'name' => 'foo'
+                ]
+            ]
         ], 200),
         GetUserRequest::class => MockResponse::make([
             'id' => 1,
@@ -50,6 +59,29 @@ test('it can get all users', function () {
         ]);
 
     $this->mockClient->assertSent(GetUsersRequest::class);
+});
+
+test('it can search users', function () {
+    $response = $this->connector->users()->search([
+        'filters' => [
+            ['field' => 'name', 'value' => 'foo']
+        ]
+    ]);
+
+    $data = $response->json();
+
+    expect($response->status())->toEqual(200)
+        ->and($response)->toBeInstanceOf(Response::class)
+        ->and($data)->toEqual([
+            'data' => [
+                [
+                    'id' => 1,
+                    'name' => 'foo'
+                ]
+            ]
+        ]);
+
+    $this->mockClient->assertSent(SearchUsersRequest::class);
 });
 
 test('it can get a user', function () {


### PR DESCRIPTION
Adds the ability to use the search endpoints.

Context: To create the Invision Migration application we need to check if a resource already exists before creating it, otherwise running the migration multiple times will lead to duplicate data in PERSCOM.io. Doing a check on the ID will not work, a resource in Invision with ID X is not guaranteed to be the same resource on PERSCOM.io.