### PR TITLE
add missing types on FilterObject's value field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v1.0.7 - 2024-02-10
+
+### What's Changed
+
+* Bump pestphp/pest-plugin-type-coverage from 2.4.0 to 2.8.0 by @dependabot in https://github.com/DeschutesDesignGroupLLC/perscom-php-sdk/pull/29
+* Add search filtering and sorting by @JonErickson in https://github.com/DeschutesDesignGroupLLC/perscom-php-sdk/pull/30
+
+**Full Changelog**: https://github.com/DeschutesDesignGroupLLC/perscom-php-sdk/compare/v1.0.6...v1.0.7
+
 ## v1.0.6 - 2024-01-29
 
 ### What's Changed

--- a/src/Data/FilterObject.php
+++ b/src/Data/FilterObject.php
@@ -9,16 +9,20 @@ class FilterObject implements Arrayable
     /**
      * @param string $field
      * @param string $operator The supported operators are '<', '<=', '>', '>=', '=', '!=', 'like', 'not like', 'in', 'not in'.
-     * @param string $value
+     * @param mixed $value
      * @param string $type The supported types are 'or' and 'and'. Defaults to OR.
      */
-    public function __construct(public string $field, public string $operator, public string $value, public string $type = 'or')
-    {
+    public function __construct(
+        public string $field,
+        public string $operator,
+        public mixed $value,
+        public string $type = 'or'
+    ) {
         //
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, mixed>
      */
     public function toArray(): array
     {
@@ -26,7 +30,7 @@ class FilterObject implements Arrayable
             'field' => $this->field,
             'operator' => $this->operator,
             'value' => $this->value,
-            'type' => $this->type
+            'type' => $this->type,
         ];
     }
 }


### PR DESCRIPTION
An argument could be made to allow `mixed`.

But that would allow objects, which honestly, kinda makes sense? For example an object with public fields, or that implements `JsonSerializable`?