### PR TITLE
fix type annotation in FilterObject

### DIFF
--- a/src/Data/FilterObject.php
+++ b/src/Data/FilterObject.php
@@ -11,7 +11,7 @@ final class FilterObject implements Arrayable
     /**
      * @param  string  $field  The field to perform the filter on.
      * @param  string  $operator  The supported operators are '<', '<=', '>', '>=', '=', '!=', 'like', 'not like', 'in', 'not in'.
-     * @param  string  $value  The value to filter by.
+     * @param  mixed  $value  The value to filter by.
      * @param  string  $type  The supported types are 'or' and 'and'. Defaults to OR.
      */
     public function __construct(


### PR DESCRIPTION
Type annotation does not match type-hint, causing static analysis tools to provide bad feedback.

For example in PHPStan:
code:
```php
$qualifications = $this->perscomFactory
    ->getPerscom()
    ->qualifications()
    ->search(filter: new FilterObject('id', 'in', [1, 2, 3]))
    ->json('data')
;
```
phpstan:
```
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------
  Line   Perscom/Twig/PerscomCourseExtensionRuntime.php
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------
  29     Parameter #3 $value of class Perscom\Data\FilterObject constructor expects string, array given.
         🪪  argument.type
```